### PR TITLE
Fix spelling errors

### DIFF
--- a/gtk2vte.pas
+++ b/gtk2vte.pas
@@ -126,7 +126,7 @@ begin
   Result := Loaded;
 end;
 
-function TerminalAvaiable: Boolean;
+function TerminalAvailable: Boolean;
 begin
   Result := TerminalLoad;
 end;

--- a/terminalctrls.pas
+++ b/terminalctrls.pas
@@ -129,7 +129,7 @@ type
     property OnTerminate;
   end;
 
-function TerminalAvaiable: Boolean;
+function TerminalAvailable: Boolean;
 
 implementation
 
@@ -145,7 +145,7 @@ uses
   NoVte;
 {$endif}
 
-function TerminalAvaiable: Boolean;
+function TerminalAvailable: Boolean;
 begin
   Result := TerminalLoad;
 end;


### PR DESCRIPTION
'Available' is spelled wrongly in 'TerminalAvaiable' in terminalctrls.pas and gtk2vte.pas.